### PR TITLE
fix(index.us) - Absolute routes to css and javascript

### DIFF
--- a/app/pages/index.us
+++ b/app/pages/index.us
@@ -2,7 +2,7 @@
 <html ng-app="app">
   <head>
     <title><%= pkg.name %></title>
-    <link rel="stylesheet" type="text/css" href="css/app.css" media="all" />
+    <link rel="stylesheet" type="text/css" href="/css/app.css" media="all" />
   </head>
   <body>
     <div class="row">
@@ -12,6 +12,6 @@
       </div>
     </div>
 
-    <script type="text/javascript" src="js/app.js"></script>
+    <script type="text/javascript" src="/js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Seems like relative paths to the `app.cs` and `app.js` doesn't work if you have routes with params like `/foo/:id`. Both `ngRoute` and `ui-router`.

Cheers.
