### PR TITLE
Let npm update protractor with new versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "grunt-angular-templates": "0.3.8",
     "grunt-ngmin": "~0.0.3",
-    "protractor": "~0.8.0",
+    "protractor": ">=0.8.0",
     "jasmine-given": "~2.1.0",
     "grunt": "~0.4.1",
     "grunt-concat-sourcemap": "~0.3.0",


### PR DESCRIPTION
I think that protractor is one of those dependencies that doesn't hurt to have at the last version because it is just in its early stages with a lot of bugs (@searls knows what I am talking about :P).

TL;DR; I think that having protractor in the last version doesn't hurt. Feel free to change it to ~0.10.0 or what you want :)
