### PR TITLE
upgrade Lineman to 0.28.0; add lineman-less

### DIFF
--- a/app/css/main.less
+++ b/app/css/main.less
@@ -1,0 +1,5 @@
+// Main less file for your application.
+// Use `@import` to use other less files
+// relative to 'app/css' or 'vendor/css'.
+
+@import 'style';

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "devDependencies": {
     "protractor": ">=0.8.0",
     "jasmine-given": "~2.1.0",
-    "lineman": ">= 0.23.0",
+    "lineman": ">= 0.28.0",
     "lineman-angular": ">= 0.2.0",
+    "lineman-less": "0.0.1",
     "coffee-script": "~1.6.3"
   },
   "scripts": {


### PR DESCRIPTION
Broke my build the other day when 0.28.0 came out because I didn't have my Lineman version locked down. Still, this is all I have to do to upgrade, right?
