### PR TITLE
Update e2e tests to use webdriver-manager from protractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ To run the unit tests:
 
 To run the end-to-end tests:
 
-1. `npm install protractor`
-2. `brew install selenium-server-standalone`
-3. Make sure you have chrome installed.
-4. `lineman run` from 1 terminal window
-5. `lineman grunt spec-e2e` from another terminal window
+1. `./node_modules/protractor/bin/webdriver-manager update`
+2. Make sure you have chrome installed.
+3. `lineman run` from 1 terminal window
+4. `lineman grunt spec-e2e` from another terminal window
 
   Troubleshooting:
 

--- a/config/spec-e2e.js
+++ b/config/spec-e2e.js
@@ -9,7 +9,7 @@ exports.config = {
   // 3. sauceUser/sauceKey - to use remote Selenium servers via SauceLabs.
 
   // The location of the selenium standalone server .jar file.
-  seleniumServerJar: '/usr/local/opt/selenium-server-standalone/selenium-server-standalone-2.37.0.jar',
+  seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.40.0.jar',
   // The port to start the selenium server on, or null if the server should
   // find its own unused port.
   seleniumPort: null,


### PR DESCRIPTION
A simplification of the installation instructions and configuration for spec-e2e to use protractor's webdriver-manager to download selenium-server and chrome driver.
